### PR TITLE
Remove support for the X-Original-Url and X-Rewrite-Url headers

### DIFF
--- a/library/Zend/Controller/Request/Apache404.php
+++ b/library/Zend/Controller/Request/Apache404.php
@@ -46,9 +46,7 @@ class Zend_Controller_Request_Apache404 extends Zend_Controller_Request_Http
     {
         $parseUriGetVars = false;
         if ($requestUri === null) {
-            if (isset($_SERVER['HTTP_X_REWRITE_URL'])) { // check this first so IIS will catch
-                $requestUri = $_SERVER['HTTP_X_REWRITE_URL'];
-            } elseif (isset($_SERVER['REDIRECT_URL'])) {  // Check if using mod_rewrite
+            eif (isset($_SERVER['REDIRECT_URL'])) {  // Check if using mod_rewrite
                 $requestUri = $_SERVER['REDIRECT_URL'];
                 if (isset($_SERVER['REDIRECT_QUERY_STRING'])) {
                     $parseUriGetVars = $_SERVER['REDIRECT_QUERY_STRING'];

--- a/library/Zend/Controller/Request/Http.php
+++ b/library/Zend/Controller/Request/Http.php
@@ -390,13 +390,7 @@ class Zend_Controller_Request_Http extends Zend_Controller_Request_Abstract
     public function setRequestUri($requestUri = null)
     {
         if ($requestUri === null) {
-            if (isset($_SERVER['HTTP_X_ORIGINAL_URL'])) { 
-                // IIS with Microsoft Rewrite Module
-                $requestUri = $_SERVER['HTTP_X_ORIGINAL_URL'];
-            } elseif (isset($_SERVER['HTTP_X_REWRITE_URL'])) { 
-                // IIS with ISAPI_Rewrite
-                $requestUri = $_SERVER['HTTP_X_REWRITE_URL'];
-            } elseif (
+            if (
                 // IIS7 with URL Rewrite: make sure we get the unencoded url (double slash problem)
                 isset($_SERVER['IIS_WasUrlRewritten'])
                 && $_SERVER['IIS_WasUrlRewritten'] == '1'

--- a/library/Zend/Feed/Pubsubhubbub/CallbackAbstract.php
+++ b/library/Zend/Feed/Pubsubhubbub/CallbackAbstract.php
@@ -223,11 +223,7 @@ abstract class Zend_Feed_Pubsubhubbub_CallbackAbstract
     protected function _detectCallbackUrl()
     {
         $callbackUrl = '';
-        if (isset($_SERVER['HTTP_X_ORIGINAL_URL'])) {
-            $callbackUrl = $_SERVER['HTTP_X_ORIGINAL_URL'];
-        } elseif (isset($_SERVER['HTTP_X_REWRITE_URL'])) {
-            $callbackUrl = $_SERVER['HTTP_X_REWRITE_URL'];
-        } elseif (isset($_SERVER['REQUEST_URI'])) {
+        if (isset($_SERVER['REQUEST_URI'])) {
             $callbackUrl = $_SERVER['REQUEST_URI'];
             $scheme = 'http';
             if ($_SERVER['HTTPS'] == 'on') {

--- a/library/Zend/OpenId.php
+++ b/library/Zend/OpenId.php
@@ -124,13 +124,7 @@ class Zend_OpenId
         }
 
         $url .= $port;
-        if (isset($_SERVER['HTTP_X_ORIGINAL_URL'])) { 
-            // IIS with Microsoft Rewrite Module
-            $url .= $_SERVER['HTTP_X_ORIGINAL_URL'];
-        } elseif (isset($_SERVER['HTTP_X_REWRITE_URL'])) {
-            // IIS with ISAPI_Rewrite 
-            $url .= $_SERVER['HTTP_X_REWRITE_URL'];
-        } elseif (isset($_SERVER['REQUEST_URI'])) {
+        if (isset($_SERVER['REQUEST_URI'])) {
             $query = strpos($_SERVER['REQUEST_URI'], '?');
             if ($query === false) {
                 $url .= $_SERVER['REQUEST_URI'];

--- a/library/Zend/Soap/AutoDiscover.php
+++ b/library/Zend/Soap/AutoDiscover.php
@@ -268,11 +268,7 @@ class Zend_Soap_AutoDiscover implements Zend_Server_Interface
      */
     protected function getRequestUriWithoutParameters()
     {
-        if (isset($_SERVER['HTTP_X_ORIGINAL_URL'])) { // IIS with Microsoft Rewrite Module
-            $requestUri = $_SERVER['HTTP_X_ORIGINAL_URL'];
-        } elseif (isset($_SERVER['HTTP_X_REWRITE_URL'])) { // check this first so IIS will catch
-            $requestUri = $_SERVER['HTTP_X_REWRITE_URL'];
-        } elseif (isset($_SERVER['REQUEST_URI'])) {
+        if (isset($_SERVER['REQUEST_URI'])) {
             $requestUri = $_SERVER['REQUEST_URI'];
         } elseif (isset($_SERVER['ORIG_PATH_INFO'])) { // IIS 5.0, PHP as CGI
             $requestUri = $_SERVER['ORIG_PATH_INFO'];


### PR DESCRIPTION
This patch modifies the logic of `Zend_Controller_Request_Http::setRequestUri()`
such that it will ignore the X-Original-Url and X-Rewrite-Url headers
when marshaling the request URI.